### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "version": "0.5.0",
   "main": "./index.js",
   "dependencies": {
-    "cheerio": "^0.18.0",
+    "cheerio": "^0.19.0",
     "he": "^0.5.0",
-    "highlight.js": "^8.4.0",
+    "highlight.js": "^9.1.0",
     "loader-utils": "^0.2.12"
   },
   "devDependencies": {
-    "html-loader": "^0.2.3",
+    "html-loader": "^0.4.0",
     "markdown-loader": "^0.1.2",
     "webpack": "^1.7.2"
   },


### PR DESCRIPTION
I noticed the outdated dependencies because dependencies of cheerio <0.19 were throwing some npm warnings.
