### PR TITLE
adds exec query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Specify a language for highlight.js. Only works in combination with the `raw` pa
 
 (To specify a language for non-raw input, apply `lang-[something]` classes to your `<code>` blocks.)
 
+### exec
+
+Execute the input that `highlight-loader` receives. Useful in cases when chaining another loader which returns a function. One use case is to combine this with the [apply-loader](https://github.com/mogelbrod/apply-loader).
+
+By default, exec is `false` and simply treats its input as a string.
+
 ## Examples
 
 ```javascript
@@ -34,6 +40,9 @@ var highlightedRaw = require('html!highlight?raw=true!./example-script.js');
 
 // Reading a file's raw contents and specifying the language ...
 var highlightedRawCss = require('html!highlight?raw=true&lang=css!./example-stylesheet.css');
+
+// Reading HTML from a template loader ...
+var highlightedRenderedJadeTemplate = require('html!highlight?exec!apply!jade!./index.jade')
 ```
 
 ## Contributors

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ module.exports = function(input) {
     this && this.cacheable && this.cacheable();
     var query = loaderUtils.parseQuery(this.query);
 
+    if(query.exec) {
+        input = this.exec(input, this.resource);
+    }
+
     if(query.raw) {
         return 'module.exports = ' + JSON.stringify(highlightCode(input, query.lang));
     }


### PR DESCRIPTION
If the source/input passed in from the previous loader is a module, this simply executes it. Currently, `highlight-loader` currently only takes in a raw string. It is not uncommon for loaders to export a function.

An example of this is `jade-loader`. It exports a template function, which needs to be called in order to generate the HTML. So, we use the `apply-loader` in conjunction with this. This just appends something like this to the end of the file:

``` js
"\n\nmodule.exports = module.exports.apply(module, " + json + ")";
```

So now, the file is a module which when called, triggers the function in the original module. A loader sequence might look like `apply!jade!./index.jade`.

With this PR, you can now use the highlight loader too: `highlight?exec!apply!jade!./index.jade`. Before, it would just treat the previous loader's output code as a string, instead of executing it to obtain the generated HTML.
